### PR TITLE
Add RabbitMQ integration for sending historical events

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -160,6 +160,26 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-amqp</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+
+    <!-- Spring RabbitMQ Dependency -->
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-amqp</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+
+
   </dependencies>
 
   <repositories>

--- a/engine/src/main/java/ai/hhrdr/chainflow/engine/config/RabbitMQConfiguration.java
+++ b/engine/src/main/java/ai/hhrdr/chainflow/engine/config/RabbitMQConfiguration.java
@@ -1,0 +1,48 @@
+package ai.hhrdr.chainflow.engine.config;
+
+import org.camunda.bpm.spring.boot.starter.configuration.Ordering;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordering.DEFAULT_ORDER + 1)
+public class RabbitMQConfiguration {
+
+    @Value("${engine.rabbitmq.queue}")
+    String queueName;
+
+    @Value("${engine.rabbitmq.exchange}")
+    String exchange;
+
+    @Value("${engine.rabbitmq.routingkey}")
+    private String routingkey;
+
+    @Bean
+    Queue queue() {
+        return new Queue(queueName, false);
+    }
+
+    @Bean
+    DirectExchange exchange() {
+        return new DirectExchange(exchange);
+    }
+
+    @Bean
+    Binding binding(Queue queue, DirectExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(routingkey);
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+}

--- a/engine/src/main/java/ai/hhrdr/chainflow/engine/plugins/RabbitMQHistoricalEventsHandler.java
+++ b/engine/src/main/java/ai/hhrdr/chainflow/engine/plugins/RabbitMQHistoricalEventsHandler.java
@@ -1,0 +1,36 @@
+package ai.hhrdr.chainflow.engine.plugins;
+
+import ai.hhrdr.chainflow.engine.service.RabbitMQSender;
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RabbitMQHistoricalEventsHandler implements HistoryEventHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RabbitMQHistoricalEventsHandler.class);
+
+    @Autowired
+    private RabbitMQSender rabbitMQSender;
+
+    @Override
+    @EventListener
+    public void handleEvent(HistoryEvent historyEvent) {
+        rabbitMQSender.send(historyEvent, historyEvent.getClass().getSimpleName());
+
+    }
+
+    @Override
+    public void handleEvents(List<HistoryEvent> historyEvents) {
+
+        for (HistoryEvent historyEvent : historyEvents) {
+            handleEvent(historyEvent);
+        }
+    }
+}

--- a/engine/src/main/java/ai/hhrdr/chainflow/engine/service/RabbitMQSender.java
+++ b/engine/src/main/java/ai/hhrdr/chainflow/engine/service/RabbitMQSender.java
@@ -1,0 +1,41 @@
+package ai.hhrdr.chainflow.engine.service;
+
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.amqp.core.AmqpTemplate;
+
+
+@Service
+public class RabbitMQSender {
+
+    @Autowired
+    private AmqpTemplate rabbitTemplate;
+
+    @Value("${engine.rabbitmq.exchange}")
+    private String exchange;
+
+    @Value("${engine.rabbitmq.routingkey}")
+    private String routingkey;
+
+    @Value("${spring.rabbitmq.enabled}")
+    private Boolean enabled;
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(RabbitMQSender.class);
+
+    public void send(HistoryEvent event, String camundaEventType) {
+        if (enabled) {
+            rabbitTemplate.convertAndSend(exchange, routingkey , event);
+            LOG.debug("Send, eventType = " + camundaEventType + " msg = " + event);
+        } else {
+            LOG.info("Event skipped, rabbit disabled, eventType = " + camundaEventType + " msg = " + event);
+        }
+
+
+
+    }
+}

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -13,4 +13,12 @@ ethereum.rpcUrl=${RPC_URL:https://rpc.ankr.com/polygon_mumbai}
 ethereum.factoryAddress=${FACTORY_ADDRESS:0x8E1c92D50c4A9DD7ef46C3d77Db0A7Cb6D300f86}
 api.url=${API_URL:http://api-url.com}
 api.key=${API_KEY:api_key}
-# Not real values
+
+spring.rabbitmq.enabled=${RABBITMQ_ENABLED:false}
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port=${RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${RABBITMQ_USER:guest}
+spring.rabbitmq.password=${RABBITMQ_PASSWORD:guest}
+engine.rabbitmq.exchange=${RABBITMQ_EXCHANGE:engine.exchange}
+engine.rabbitmq.queue=${RABBITMQ_QUEUE:engine.queue}
+engine.rabbitmq.routingkey=${RABBITMQ_ROUTINGKEY:engine.routingkey}


### PR DESCRIPTION
This commit introduces RabbitMQ integration to the project,
allowing for the forwarding of Camunda historical events to RabbitMQ.
The integration is achieved through new dependencies in the pom.xml,
a new configuration class, and service handlers that manage the event
sending process. This setup enables asynchronous processing and external
handling of workflow events.